### PR TITLE
EASY-2297: 'updateIngestStep' mutation results in 'operator does not exist'

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
@@ -186,20 +186,20 @@ object QueryGenerator {
     s"SELECT identifierId, identifierSchema, identifierValue, timestamp FROM Identifier WHERE $queryWherePart;" -> valuesWherePart
   }
 
-  def getSimplePropsElementsById(tableName: String, idColumnName: String, key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
-    val query = s"SELECT * FROM $tableName WHERE key = ? AND $idColumnName IN (${ ids.toList.map(_ => "?").mkString(", ") });"
+  def getSimplePropsElementsById(idColumnName: String, key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
+    val query = s"SELECT * FROM SimpleProperties WHERE key = ? AND $idColumnName IN (${ ids.toList.map(_ => "?").mkString(", ") });"
     val values = setString(key) :: ids.map(setInt)
 
     query -> values.toList
   }
 
-  def getSimplePropsCurrentElementByDepositId(tableName: String, key: String)(ids: NonEmptyList[DepositId]): (String, Seq[PrepStatementResolver]) = {
+  def getSimplePropsCurrentElementByDepositId(key: String)(ids: NonEmptyList[DepositId]): (String, Seq[PrepStatementResolver]) = {
     val query =
       s"""SELECT *
-         |FROM $tableName
+         |FROM SimpleProperties
          |INNER JOIN (
          |  SELECT depositId, max(timestamp) AS max_timestamp
-         |  FROM $tableName
+         |  FROM SimpleProperties
          |  WHERE key = ?
          |  AND depositId IN (${ ids.toList.map(_ => "?").mkString(", ") })
          |  GROUP BY depositId
@@ -211,15 +211,15 @@ object QueryGenerator {
     query -> values.map(setString).toList
   }
 
-  def getSimplePropsAllElementsByDepositId(tableName: String, key: String)(ids: NonEmptyList[DepositId]): (String, Seq[PrepStatementResolver]) = {
-    val query = s"SELECT * FROM $tableName WHERE key = ? AND depositId IN (${ ids.toList.map(_ => "?").mkString(", ") });"
+  def getSimplePropsAllElementsByDepositId(key: String)(ids: NonEmptyList[DepositId]): (String, Seq[PrepStatementResolver]) = {
+    val query = s"SELECT * FROM SimpleProperties WHERE key = ? AND depositId IN (${ ids.toList.map(_ => "?").mkString(", ") });"
     val values = key :: ids.map(_.toString)
 
     query -> values.map(setString).toList
   }
 
-  def getSimplePropsDepositsById(tableName: String, idColumnName: String, key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
-    val query = s"SELECT $idColumnName, depositId, bagName, creationTimestamp, depositorId FROM Deposit INNER JOIN $tableName ON Deposit.depositId = $tableName.depositId WHERE key = ? AND $idColumnName IN (${ ids.toList.map(_ => "?").mkString(", ") });"
+  def getSimplePropsDepositsById(key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
+    val query = s"SELECT propertyId, depositId, bagName, creationTimestamp, depositorId FROM Deposit INNER JOIN SimpleProperties ON Deposit.depositId = SimpleProperties.depositId WHERE key = ? AND propertyId IN (${ ids.toList.map(_ => "?").mkString(", ") });"
     val values = setString(key) :: ids.map(setInt)
 
     query -> values.toList

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
@@ -219,7 +219,7 @@ object QueryGenerator {
   }
 
   def getSimplePropsDepositsById(key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
-    val query = s"SELECT propertyId, depositId, bagName, creationTimestamp, depositorId FROM Deposit INNER JOIN SimpleProperties ON Deposit.depositId = SimpleProperties.depositId WHERE key = ? AND propertyId IN (${ ids.toList.map(_ => "?").mkString(", ") });"
+    val query = s"SELECT propertyId, Deposit.depositId, bagName, creationTimestamp, depositorId FROM Deposit INNER JOIN SimpleProperties ON Deposit.depositId = SimpleProperties.depositId WHERE key = ? AND propertyId IN (${ ids.toList.map(_ => "?").mkString(", ") });"
     val values = setString(key) :: ids.map(setInt)
 
     query -> values.toList

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
@@ -186,8 +186,8 @@ object QueryGenerator {
     s"SELECT identifierId, identifierSchema, identifierValue, timestamp FROM Identifier WHERE $queryWherePart;" -> valuesWherePart
   }
 
-  def getSimplePropsElementsById(idColumnName: String, key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
-    val query = s"SELECT * FROM SimpleProperties WHERE key = ? AND $idColumnName IN (${ ids.toList.map(_ => "?").mkString(", ") });"
+  def getSimplePropsElementsById(key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
+    val query = s"SELECT * FROM SimpleProperties WHERE key = ? AND propertyId IN (${ ids.toList.map(_ => "?").mkString(", ") });"
     val values = setString(key) :: ids.map(setInt)
 
     query -> values.toList

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
@@ -188,9 +188,9 @@ object QueryGenerator {
 
   def getSimplePropsElementsById(tableName: String, idColumnName: String, key: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
     val query = s"SELECT * FROM $tableName WHERE key = ? AND $idColumnName IN (${ ids.toList.map(_ => "?").mkString(", ") });"
-    val values = key :: ids
+    val values = setString(key) :: ids.map(setInt)
 
-    query -> values.map(setString).toList
+    query -> values.toList
   }
 
   def getSimplePropsCurrentElementByDepositId(tableName: String, key: String)(ids: NonEmptyList[DepositId]): (String, Seq[PrepStatementResolver]) = {

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLContentTypeDao.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLContentTypeDao.scala
@@ -52,7 +52,7 @@ class SQLContentTypeDao(implicit connection: Connection, errorHandler: SQLErrorH
   override def getById(ids: Seq[String]): QueryErrorOr[Seq[(String, Option[ContentType])]] = {
     trace(ids)
 
-    executeGetById(parseContentType)(QueryGenerator.getSimplePropsElementsById("propertyId", "content-type"))(ids)
+    executeGetById(parseContentType)(QueryGenerator.getSimplePropsElementsById("content-type"))(ids)
   }
 
   override def getCurrent(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Option[ContentType])]] = {

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLContentTypeDao.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLContentTypeDao.scala
@@ -52,19 +52,19 @@ class SQLContentTypeDao(implicit connection: Connection, errorHandler: SQLErrorH
   override def getById(ids: Seq[String]): QueryErrorOr[Seq[(String, Option[ContentType])]] = {
     trace(ids)
 
-    executeGetById(parseContentType)(QueryGenerator.getSimplePropsElementsById("SimpleProperties", "propertyId", "content-type"))(ids)
+    executeGetById(parseContentType)(QueryGenerator.getSimplePropsElementsById("propertyId", "content-type"))(ids)
   }
 
   override def getCurrent(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Option[ContentType])]] = {
     trace(ids)
 
-    executeGetCurrent(parseDepositIdAndContentType)(QueryGenerator.getSimplePropsCurrentElementByDepositId("SimpleProperties", "content-type"))(ids)
+    executeGetCurrent(parseDepositIdAndContentType)(QueryGenerator.getSimplePropsCurrentElementByDepositId("content-type"))(ids)
   }
 
   override def getAll(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Seq[ContentType])]] = {
     trace(ids)
 
-    executeGetAll(parseDepositIdAndContentType)(QueryGenerator.getSimplePropsAllElementsByDepositId("SimpleProperties", "content-type"))(ids)
+    executeGetAll(parseDepositIdAndContentType)(QueryGenerator.getSimplePropsAllElementsByDepositId("content-type"))(ids)
   }
 
   override def store(id: DepositId, contentType: InputContentType): MutationErrorOr[ContentType] = {
@@ -103,6 +103,6 @@ class SQLContentTypeDao(implicit connection: Connection, errorHandler: SQLErrorH
   override def getDepositsById(ids: Seq[String]): QueryErrorOr[Seq[(String, Option[Deposit])]] = {
     trace(ids)
 
-    executeGetDepositById(parseContentTypeIdAndDeposit)(QueryGenerator.getSimplePropsDepositsById("SimpleProperties", "propertyId", "content-type"))(ids)
+    executeGetDepositById(parseContentTypeIdAndDeposit)(QueryGenerator.getSimplePropsDepositsById("content-type"))(ids)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLDoiActionDao.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLDoiActionDao.scala
@@ -43,13 +43,13 @@ class SQLDoiActionDao(implicit connection: Connection, errorHandler: SQLErrorHan
   override def getCurrent(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Option[DoiActionEvent])]] = {
     trace(ids)
 
-    executeGetCurrent(parseDepositIdAndDoiActionEvent)(QueryGenerator.getSimplePropsCurrentElementByDepositId("SimpleProperties", "doi-action"))(ids)
+    executeGetCurrent(parseDepositIdAndDoiActionEvent)(QueryGenerator.getSimplePropsCurrentElementByDepositId("doi-action"))(ids)
   }
 
   override def getAll(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Seq[DoiActionEvent])]] = {
     trace(ids)
 
-    executeGetAll(parseDepositIdAndDoiActionEvent)(QueryGenerator.getSimplePropsAllElementsByDepositId("SimpleProperties", "doi-action"))(ids)
+    executeGetAll(parseDepositIdAndDoiActionEvent)(QueryGenerator.getSimplePropsAllElementsByDepositId("doi-action"))(ids)
   }
 
   override def store(id: DepositId, action: DoiActionEvent): MutationErrorOr[DoiActionEvent] = {

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLDoiRegisteredDao.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLDoiRegisteredDao.scala
@@ -43,13 +43,13 @@ class SQLDoiRegisteredDao(implicit connection: Connection, errorHandler: SQLErro
   override def getCurrent(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Option[DoiRegisteredEvent])]] = {
     trace(ids)
 
-    executeGetCurrent(parseDepositIdAndDoiRegisteredEvent)(QueryGenerator.getSimplePropsCurrentElementByDepositId("SimpleProperties", "doi-registered"))(ids)
+    executeGetCurrent(parseDepositIdAndDoiRegisteredEvent)(QueryGenerator.getSimplePropsCurrentElementByDepositId("doi-registered"))(ids)
   }
 
   override def getAll(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Seq[DoiRegisteredEvent])]] = {
     trace(ids)
 
-    executeGetAll(parseDepositIdAndDoiRegisteredEvent)(QueryGenerator.getSimplePropsAllElementsByDepositId("SimpleProperties", "doi-registered"))(ids)
+    executeGetAll(parseDepositIdAndDoiRegisteredEvent)(QueryGenerator.getSimplePropsAllElementsByDepositId("doi-registered"))(ids)
   }
 
   override def store(id: DepositId, registered: DoiRegisteredEvent): MutationErrorOr[DoiRegisteredEvent] = {

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLIngestStepDao.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLIngestStepDao.scala
@@ -52,7 +52,7 @@ class SQLIngestStepDao(implicit connection: Connection, errorHandler: SQLErrorHa
   override def getById(ids: Seq[String]): QueryErrorOr[Seq[(String, Option[IngestStep])]] = {
     trace(ids)
 
-    executeGetById(parseIngestStep)(QueryGenerator.getSimplePropsElementsById("propertyId", "ingest-step"))(ids)
+    executeGetById(parseIngestStep)(QueryGenerator.getSimplePropsElementsById("ingest-step"))(ids)
   }
 
   override def getCurrent(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Option[IngestStep])]] = {

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLIngestStepDao.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLIngestStepDao.scala
@@ -52,19 +52,19 @@ class SQLIngestStepDao(implicit connection: Connection, errorHandler: SQLErrorHa
   override def getById(ids: Seq[String]): QueryErrorOr[Seq[(String, Option[IngestStep])]] = {
     trace(ids)
 
-    executeGetById(parseIngestStep)(QueryGenerator.getSimplePropsElementsById("SimpleProperties", "propertyId", "ingest-step"))(ids)
+    executeGetById(parseIngestStep)(QueryGenerator.getSimplePropsElementsById("propertyId", "ingest-step"))(ids)
   }
 
   override def getCurrent(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Option[IngestStep])]] = {
     trace(ids)
 
-    executeGetCurrent(parseDepositIdAndIngestStep)(QueryGenerator.getSimplePropsCurrentElementByDepositId("SimpleProperties", "ingest-step"))(ids)
+    executeGetCurrent(parseDepositIdAndIngestStep)(QueryGenerator.getSimplePropsCurrentElementByDepositId("ingest-step"))(ids)
   }
 
   override def getAll(ids: Seq[DepositId]): QueryErrorOr[Seq[(DepositId, Seq[IngestStep])]] = {
     trace(ids)
 
-    executeGetAll(parseDepositIdAndIngestStep)(QueryGenerator.getSimplePropsAllElementsByDepositId("SimpleProperties", "ingest-step"))(ids)
+    executeGetAll(parseDepositIdAndIngestStep)(QueryGenerator.getSimplePropsAllElementsByDepositId("ingest-step"))(ids)
   }
 
   override def store(id: DepositId, step: InputIngestStep): MutationErrorOr[IngestStep] = {
@@ -103,6 +103,6 @@ class SQLIngestStepDao(implicit connection: Connection, errorHandler: SQLErrorHa
   override def getDepositsById(ids: Seq[String]): QueryErrorOr[Seq[(String, Option[Deposit])]] = {
     trace(ids)
 
-    executeGetDepositById(parseIngestStepIdAndDeposit)(QueryGenerator.getSimplePropsDepositsById("SimpleProperties", "propertyId", "ingest-step"))(ids)
+    executeGetDepositById(parseIngestStepIdAndDeposit)(QueryGenerator.getSimplePropsDepositsById("ingest-step"))(ids)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
@@ -125,18 +125,18 @@ class QueryGeneratorPropSpec extends PropSpec with GeneratorDrivenPropertyChecks
   }
 
   property("getSimplePropsElementsById") {
-    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsElementsById("table", "idColumn", "key"))
+    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsElementsById("idColumn", "key"))
   }
 
   property("getSimplePropsCurrentElementByDepositId") {
-    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsCurrentElementByDepositId("table", "key"))
+    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsCurrentElementByDepositId("key"))
   }
 
   property("getSimplePropsAllElementsByDepositId") {
-    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsAllElementsByDepositId("table", "key"))
+    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsAllElementsByDepositId("key"))
   }
 
   property("getSimplePropsDepositsById") {
-    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsDepositsById("table", "idColumn", "key"))
+    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsDepositsById("key"))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
@@ -125,7 +125,7 @@ class QueryGeneratorPropSpec extends PropSpec with GeneratorDrivenPropertyChecks
   }
 
   property("getSimplePropsElementsById") {
-    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsElementsById("idColumn", "key"))
+    testNumberOfQuestionMarks(QueryGenerator.getSimplePropsElementsById("key"))
   }
 
   property("getSimplePropsCurrentElementByDepositId") {


### PR DESCRIPTION
Fixes EASY-2297

#### When applied it will
* fix the SQL `ResultSet` parser for getSimplePropsElementsById
* avoid an ambiguity in the `SELECT` from getSimplePropsDepositsById
* inline a number of parameters because they have the same value all the time

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* [x] the changes have been tested on `deasy`

@DANS-KNAW/easy for review