### PR TITLE
EASY-2295: add UPDATE permission on deposit table to easy_deposit_properties

### DIFF
--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -63,7 +63,7 @@ CREATE TABLE SimpleProperties (
     UNIQUE (depositId, key, timestamp)
 );
 
-GRANT INSERT, SELECT ON Deposit TO easy_deposit_properties;
+GRANT INSERT, UPDATE, SELECT ON Deposit TO easy_deposit_properties;
 GRANT INSERT, SELECT ON State TO easy_deposit_properties;
 GRANT INSERT, SELECT ON Identifier TO easy_deposit_properties;
 GRANT INSERT, SELECT ON Curation TO easy_deposit_properties;


### PR DESCRIPTION
Fixes EASY-2295

#### When applied it will
* add UPDATE permission on deposit table to easy_deposit_properties

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* [x] the changes have been tested on `deasy`

@DANS-KNAW/easy for review