### PR TITLE
EASY-2299: timebased search also works correctly for empty lists

### DIFF
--- a/src/test/resources/graphql-examples/deposit/timebasedSearch/invalidOnEmptyList.graphql
+++ b/src/test/resources/graphql-examples/deposit/timebasedSearch/invalidOnEmptyList.graphql
@@ -1,0 +1,13 @@
+query {
+    deposit(id: "00000000-0000-0000-0000-000000000002") {
+        curators(earlierThan: "2019-01-01T04:00:00.000Z", atTimestamp: "2019-01-01T02:00:00.000Z") {
+            edges {
+                node {
+                    userId
+                    email
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/deposit/timebasedSearch/invalidOnEmptyList.json
+++ b/src/test/resources/graphql-examples/deposit/timebasedSearch/invalidOnEmptyList.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "deposit": {
+      "curators": null
+    }
+  },
+  "errors": [
+    {
+      "message": "argument 'atTimestamp' cannot be used in conjunction with arguments 'earlierThan' or 'laterThan'",
+      "path": [
+        "deposit",
+        "curators"
+      ],
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes EASY-2299

#### When applied it will
* properly handle timebased search on empty

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* [x] the changes have been tested on `deasy`

@DANS-KNAW/easy for review