### PR TITLE
EASY-2308: disambiguate the depositId column in queries for getting the deposit by id

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGenerator.scala
@@ -155,7 +155,7 @@ object QueryGenerator {
   }
 
   def getDepositsById(tableName: String, idColumnName: String)(ids: NonEmptyList[String]): (String, Seq[PrepStatementResolver]) = {
-    val query = s"SELECT $idColumnName, depositId, bagName, creationTimestamp, depositorId FROM Deposit INNER JOIN $tableName ON Deposit.depositId = $tableName.depositId WHERE $idColumnName IN (${ ids.toList.map(_ => "?").mkString(", ") });"
+    val query = s"SELECT $idColumnName, Deposit.depositId, bagName, creationTimestamp, depositorId FROM Deposit INNER JOIN $tableName ON Deposit.depositId = $tableName.depositId WHERE $idColumnName IN (${ ids.toList.map(_ => "?").mkString(", ") });"
 
     query -> ids.map(setInt).toList
   }

--- a/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorSpec.scala
@@ -460,7 +460,7 @@ class QueryGeneratorSpec extends TestSupportFixture with MockFactory {
     val (query, values) = QueryGenerator.getDepositsById("State", "stateId")(ids)
 
     val expectedQuery =
-      """SELECT stateId, depositId, bagName, creationTimestamp, depositorId
+      """SELECT stateId, Deposit.depositId, bagName, creationTimestamp, depositorId
         |FROM Deposit
         |INNER JOIN State
         |ON Deposit.depositId = State.depositId


### PR DESCRIPTION
Fixes EASY-2308

#### When applied it will
* add the specific table name in a select to disambiguate the depositId column in queries for getting the deposit by id

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* [x] the changes have been tested on `deasy`

@DANS-KNAW/easy for review