### PR TITLE
EASY-2335: remove BAGINDEX ingest step

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -983,9 +983,6 @@ enum IngestStepLabel {
   """The file content of the deposit's payload is being index."""
   SOLR4FILES
 
-  """Indexing the archival copy and its relation to other bags."""
-  BAGINDEX
-
   """Creating an archival copy of the deposit for storage in the vault."""
   BAGSTORE
 

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/types/IngestStepType.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/types/IngestStepType.scala
@@ -44,7 +44,6 @@ trait IngestStepType {
     DocumentValue("FEDORA", "A dissemination copy of the deposit is being made in Fedora."),
     DocumentValue("SPRINGFIELD", "Dissemination copies of the audio/video files in the deposit are being made in Springfield."),
     DocumentValue("BAGSTORE", "Creating an archival copy of the deposit for storage in the vault."),
-    DocumentValue("BAGINDEX", "Indexing the archival copy and its relation to other bags."),
     DocumentValue("SOLR4FILES", "The file content of the deposit's payload is being index."),
     DocumentValue("COMPLETED", "The ingest process of this deposit has completed."),
   )

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/model/ingestStep/IngestStepLabel.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/model/ingestStep/IngestStepLabel.scala
@@ -24,7 +24,6 @@ object IngestStepLabel extends Enumeration {
   val FEDORA       : IngestStepLabel = Value("FEDORA")
   val SPRINGFIELD  : IngestStepLabel = Value("SPRINGFIELD")
   val BAGSTORE     : IngestStepLabel = Value("BAGSTORE")
-  val BAGINDEX     : IngestStepLabel = Value("BAGINDEX") // TODO seems never used in easy-ingest-flow
   val SOLR4FILES   : IngestStepLabel = Value("SOLR4FILES")
   val COMPLETED    : IngestStepLabel = Value("COMPLETED") // TODO new state instead of removing it from the properties
   // @formatter:on

--- a/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLIngestStepDaoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/SQLIngestStepDaoSpec.scala
@@ -101,8 +101,8 @@ class SQLIngestStepDaoSpec extends TestSupportFixture
   "store" should "insert a new ingest step into the database" in {
     val ingestSteps = new SQLIngestStepDao
     val timestamp = new DateTime(2019, 7, 19, 22, 45, timeZone)
-    val inputIngestStep = InputIngestStep(IngestStepLabel.BAGINDEX, timestamp)
-    val expectedIngestStep = IngestStep("32", IngestStepLabel.BAGINDEX, timestamp)
+    val inputIngestStep = InputIngestStep(IngestStepLabel.BAGSTORE, timestamp)
+    val expectedIngestStep = IngestStep("32", IngestStepLabel.BAGSTORE, timestamp)
 
     ingestSteps.store(depositId4, inputIngestStep).value shouldBe expectedIngestStep
     ingestSteps.getById(Seq("32")).value should contain only expectedIngestStep
@@ -114,7 +114,7 @@ class SQLIngestStepDaoSpec extends TestSupportFixture
     val ingestSteps = new SQLIngestStepDao
     val depositId6 = UUID.fromString("00000000-0000-0000-0000-000000000006")
     val timestamp = new DateTime(2019, 7, 18, 22, 38, timeZone)
-    val inputIngestStep = InputIngestStep(IngestStepLabel.BAGINDEX, timestamp)
+    val inputIngestStep = InputIngestStep(IngestStepLabel.BAGSTORE, timestamp)
 
     ingestSteps.store(depositId6, inputIngestStep).leftValue shouldBe NoSuchDepositError(depositId6)
   }
@@ -123,8 +123,8 @@ class SQLIngestStepDaoSpec extends TestSupportFixture
     val ingestSteps = new SQLIngestStepDao
     val depositId = depositId1
     val timestamp = new DateTime(2019, 1, 1, 6, 6, timeZone)
-    val inputIngestStep1 = InputIngestStep(IngestStepLabel.BAGINDEX, timestamp)
-    val inputIngestStep2 = InputIngestStep(IngestStepLabel.BAGSTORE, timestamp)
+    val inputIngestStep1 = InputIngestStep(IngestStepLabel.BAGSTORE, timestamp)
+    val inputIngestStep2 = InputIngestStep(IngestStepLabel.SOLR4FILES, timestamp)
 
     ingestSteps.store(depositId, inputIngestStep1) shouldBe right
     ingestSteps.store(depositId, inputIngestStep2).leftValue shouldBe DepositIdAndTimestampAlreadyExistError(depositId, timestamp, "ingest step")


### PR DESCRIPTION
Fixes EASY-2335

#### When applied it will
* remove the `BAGINDEX` ingest step

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* ~the changes have been tested on `deasy`~

@DANS-KNAW/easy for review