### PR TITLE
NO-JIRA: tests for the use of variables in a GraphQL query or mutation

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.properties/server/GraphQLServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/server/GraphQLServlet.scala
@@ -29,7 +29,7 @@ import nl.knaw.dans.lib.logging.servlet.{ LogResponseBodyOnError, MaskedLogForma
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
 import org.json4s.ext.UUIDSerializer
-import org.json4s.native.{ JsonMethods, Serialization }
+import org.json4s.native.Serialization
 import org.json4s.{ DefaultFormats, Formats, JValue }
 import org.scalatra._
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
@@ -120,12 +120,6 @@ class GraphQLServlet(database: DatabaseAccess,
       .recover {
         case error => InternalServerError(Serialization.write(error.getMessage))
       }
-  }
-
-  private def parseVariables(optS: Option[String]): JValue = {
-    optS.filter(s => s.trim != "" && s.trim != "null")
-      .map(JsonMethods.parse(_))
-      .getOrElse(Nil)
   }
 
   private def syntaxError(error: SyntaxError): String = {


### PR DESCRIPTION
~Fixes EASY-~

#### When applied it will
* add tests for the use of variables in a GraphQL query or mutation after https://github.com/DANS-KNAW/easy-deposit-properties/pull/16

@DANS-KNAW/easy for review