### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
 
         <!-- Apache Commons -->

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/Scalars.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/Scalars.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.properties.app.graphql.model
 import java.util.UUID
 
 import cats.syntax.either._
+import nl.knaw.dans.lib.string._
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import sangria.ast.StringValue
@@ -29,7 +30,7 @@ trait Scalars {
   case object UUIDCoercionViolation extends ValueCoercionViolation("UUID value expected")
 
   private def parseUUID(s: String): Either[Violation, UUID] = {
-    Either.catchNonFatal { UUID.fromString(s) }
+    s.toUUID
       .fold(_ => UUIDCoercionViolation.asLeft, _.asRight)
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/typedefinitions/GraphQLQueryType.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/typedefinitions/GraphQLQueryType.scala
@@ -23,6 +23,8 @@ import nl.knaw.dans.easy.properties.app.graphql.resolvers._
 import sangria.macros.derive._
 import sangria.relay.{ GlobalId, Node, NodeDefinition }
 import sangria.schema.{ Context, ObjectType }
+import nl.knaw.dans.lib.string._
+import nl.knaw.dans.lib.error._
 
 trait GraphQLQueryType {
   this: Scalars
@@ -52,7 +54,7 @@ trait GraphQLQueryType {
             CurationResolver.curationById(id.id)
               .map(_.map(curation => new GraphQLCurator(curation.getCurator)))
           case GraphQLDepositType.name =>
-            DepositResolver.depositById(UUID.fromString(id.id))
+            DepositResolver.depositById(id.id.toUUID.toTry.unsafeGetOrThrow)
               .map(_.map(new GraphQLDeposit(_)))
           case GraphQLIdentifierType.name =>
             IdentifierResolver.identifierById(id.id)

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/legacyImport/ImportProps.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/legacyImport/ImportProps.scala
@@ -36,6 +36,7 @@ import nl.knaw.dans.easy.properties.app.model.{ Deposit, DepositId, DoiAction, D
 import nl.knaw.dans.easy.properties.app.repository.{ MutationErrorOr, Repository }
 import nl.knaw.dans.easy.{ DataciteService, DataciteServiceException }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.lang.BooleanUtils
 import org.joda.time.DateTime
@@ -97,11 +98,7 @@ class ImportProps(repository: Repository, interactor: Interactor, datacite: Data
     file.parentOption
       .map(_.name.asRight)
       .getOrElse { NoSuchParentDirError(file).asLeft }
-      .flatMap(s => parseDepositId(s).leftMap(_ => NoDepositIdError(s)))
-  }
-
-  private def parseDepositId(s: String): Either[IllegalArgumentException, DepositId] = {
-    Either.catchOnly[IllegalArgumentException](UUID.fromString(s))
+      .flatMap(s => s.toUUID.leftMap(_ => NoDepositIdError(s)))
   }
 
   private def storeProp[T](props: PropertiesConfiguration, key: String)(value: T): T = {

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/CommonResultSetParsers.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/repository/sql/CommonResultSetParsers.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.properties.app.repository.sql
 
 import java.sql.{ Connection, ResultSet }
-import java.util.UUID
 
 import cats.data.NonEmptyList
 import cats.instances.either._
@@ -25,6 +24,7 @@ import cats.syntax.either._
 import cats.syntax.traverse._
 import nl.knaw.dans.easy.properties.app.model.{ Deposit, DepositId, Origin, Timestamp }
 import nl.knaw.dans.easy.properties.app.repository.{ InvalidValueError, QueryErrorOr }
+import nl.knaw.dans.lib.string._
 import org.joda.time.{ DateTime, DateTimeZone }
 import resource.managed
 import sangria.relay.Node
@@ -40,7 +40,7 @@ private[sql] trait CommonResultSetParsers {
   }
 
   private[sql] def parseDepositId(s: String): Either[InvalidValueError, DepositId] = {
-    Either.catchOnly[IllegalArgumentException] { UUID.fromString(s) }
+    s.toUUID
       .leftMap(_ => InvalidValueError(s"Invalid depositId value: '$s'"))
   }
 

--- a/src/test/resources/graphql-examples/node/onDepositInvalid.graphql
+++ b/src/test/resources/graphql-examples/node/onDepositInvalid.graphql
@@ -1,0 +1,14 @@
+query {
+    node(id: "RGVwb3NpdDox"){
+        ... on Deposit {
+            id
+            depositId
+            creationTimestamp
+            state {
+                label
+                description
+                timestamp
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/node/onDepositInvalid.json
+++ b/src/test/resources/graphql-examples/node/onDepositInvalid.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "node": null
+  },
+  "errors": [
+    {
+      "message": "String '1' is not a UUID",
+      "path": [
+        "node"
+      ],
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

#### By submitting this pull request I confirm that
* [ ] the changes have been tested on `deasy`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..

