### PR TITLE
Relay validation: pagination queries should have either 'first' or 'last' argument

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/relay/RelayValidation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/relay/RelayValidation.scala
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.properties.app.graphql.relay
+
+import nl.knaw.dans.easy.properties.app.graphql.relay.RelayViolations._
+import sangria.ast._
+import sangria.validation.{ ValidationContext, ValidationRule }
+
+object RelayValidation {
+
+  val allRules: List[ValidationRule] = List(
+    new ConnectionHasEitherFirstOrLast,
+  )
+
+  class ConnectionHasEitherFirstOrLast extends ValidationRule {
+    override def visitor(ctx: ValidationContext): AstValidatingVisitor = new AstValidatingVisitor {
+
+      private var visitedNodes = List.empty[AstNode]
+
+      override def onEnter: ValidationVisit = {
+        case f @ Field(_, "edges", _, _, _, _, _, _) =>
+          val stackHead = visitedNodes.headOption
+          visitedNodes = f :: visitedNodes
+          stackHead
+            .fold(AstVisitorCommand.RightContinue) {
+              case Field(_, fieldName, arguments, _, _, _, _, pos) =>
+                arguments.map(_.name).filter {
+                  case "first" | "last" => true
+                  case _ => false
+                }.toSet.toList match {
+                  case Nil =>
+                    Left(Vector(MissingFirstOrLastArgumentViolation(fieldName, ctx.sourceMapper, pos.toList)))
+                  case "first" :: Nil | "last" :: Nil =>
+                    AstVisitorCommand.RightContinue
+                  case _ =>
+                    Left(Vector(BothFirstOrLastArgumentViolation(fieldName, ctx.sourceMapper, pos.toList)))
+                }
+              case _ => AstVisitorCommand.RightContinue
+            }
+        case astNode =>
+          visitedNodes = astNode :: visitedNodes
+          AstVisitorCommand.RightContinue
+      }
+
+      override def onLeave: ValidationVisit = {
+        case d: Document =>
+          visitedNodes match {
+            case `d` :: Nil => AstVisitorCommand.RightContinue
+            case _ => throw new Exception(s"unexpected non-empty stack on exiting $d")
+          }
+        case astNode if visitedNodes.isEmpty =>
+          throw new Exception(s"unexpected empty stack on exiting $astNode")
+        case _ =>
+          visitedNodes = visitedNodes.tail
+          AstVisitorCommand.RightContinue
+      }
+    }
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/relay/RelayViolations.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/relay/RelayViolations.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.properties.app.graphql.relay
+
+import sangria.ast.AstLocation
+import sangria.parser.SourceMapper
+import sangria.validation.AstNodeViolation
+
+object RelayViolations {
+
+  case class MissingFirstOrLastArgumentViolation(fieldName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
+    override lazy val simpleErrorMessage: String = s"You must provide a `first` or `last` value to properly paginate the `$fieldName` connection."
+  }
+
+  case class BothFirstOrLastArgumentViolation(fieldName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
+    override lazy val simpleErrorMessage: String = s"Passing both `first` and `last` to paginate the `$fieldName` connection is not supported."
+  }
+}

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorBothFirstAndLastInPagination.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorBothFirstAndLastInPagination.graphql
@@ -1,0 +1,13 @@
+query {
+    deposit(id: "00000000-0000-0000-0000-000000000001") {
+        curators(first: 10, last: 10) { # too much pagination
+            edges {
+                node {
+                    userId
+                    email
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorBothFirstAndLastInPagination.json
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorBothFirstAndLastInPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Passing both `first` and `last` to paginate the `curators` connection is not supported. (line 3, column 9):\n        curators(first: 10, last: 10) { # too much pagination\n        ^",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorWithoutPagination.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorWithoutPagination.graphql
@@ -1,0 +1,13 @@
+query {
+    deposit(id: "00000000-0000-0000-0000-000000000001") {
+        curators { # no pagination
+            edges {
+                node {
+                    userId
+                    email
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorWithoutPagination.json
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/errorWithoutPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "You must provide a `first` or `last` value to properly paginate the `curators` connection. (line 3, column 9):\n        curators { # no pagination\n        ^",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        curators(orderBy: {field: TIMESTAMP, direction: ASC}) {
+        curators(first: 10, orderBy: {field: TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     userId

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        curators(orderBy: {field: TIMESTAMP, direction: DESC}) {
+        curators(first: 10, orderBy: {field: TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     userId

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByUserIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByUserIdAscending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        curators(orderBy: {field: USERID, direction: ASC}) {
+        curators(first: 10, orderBy: {field: USERID, direction: ASC}) {
             edges {
                 node {
                     userId

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByUserIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/orderedByUserIdDescending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        curators(orderBy: {field: USERID, direction: DESC}) {
+        curators(first: 10, orderBy: {field: USERID, direction: DESC}) {
             edges {
                 node {
                     userId

--- a/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllCuratorsOfDeposit/plain.graphql
@@ -1,6 +1,6 @@
 query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        curators {
+        curators(first: 10) {
             edges {
                 node {
                     userId

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorBothFirstAndLastInPagination.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorBothFirstAndLastInPagination.graphql
@@ -1,0 +1,14 @@
+query ListAllStatesOfDeposit {
+    deposit(id: "00000000-0000-0000-0000-000000000001") {
+        ingestSteps(first: 10, last: 10) { # too much pagination
+            edges {
+                node {
+                    id
+                    step
+                    timestamp
+                }
+            }
+        }
+    }
+}
+

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorBothFirstAndLastInPagination.json
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorBothFirstAndLastInPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Passing both `first` and `last` to paginate the `ingestSteps` connection is not supported. (line 3, column 9):\n        ingestSteps(first: 10, last: 10) { # too much pagination\n        ^",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorWithoutPagination.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorWithoutPagination.graphql
@@ -1,0 +1,14 @@
+query ListAllStatesOfDeposit {
+    deposit(id: "00000000-0000-0000-0000-000000000001") {
+        ingestSteps { # no pagination
+            edges {
+                node {
+                    id
+                    step
+                    timestamp
+                }
+            }
+        }
+    }
+}
+

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorWithoutPagination.json
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/errorWithoutPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "You must provide a `first` or `last` value to properly paginate the `ingestSteps` connection. (line 3, column 9):\n        ingestSteps { # no pagination\n        ^",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByStepAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByStepAscending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        ingestSteps(orderBy: {field: STEP, direction: ASC}) {
+        ingestSteps(first: 10, orderBy: {field: STEP, direction: ASC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByStepDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByStepDescending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        ingestSteps(orderBy: {field: STEP, direction: DESC}) {
+        ingestSteps(first: 10, orderBy: {field: STEP, direction: DESC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        ingestSteps(orderBy: {field: TIMESTAMP, direction: ASC}) {
+        ingestSteps(first: 10, orderBy: {field: TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/orderedByTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        ingestSteps(orderBy: {field: TIMESTAMP, direction: DESC}) {
+        ingestSteps(first: 10, orderBy: {field: TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllIngestStepsOfDeposit/plain.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        ingestSteps {
+        ingestSteps(first: 10) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorBothFirstAndLastInPagination.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorBothFirstAndLastInPagination.graphql
@@ -1,0 +1,14 @@
+query ListAllStatesOfDeposit {
+    deposit(id: "00000000-0000-0000-0000-000000000001") {
+        states(first: 10, last: 10) { # too much pagination
+            edges {
+                node {
+                    id
+                    label
+                    description
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorBothFirstAndLastInPagination.json
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorBothFirstAndLastInPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Passing both `first` and `last` to paginate the `states` connection is not supported. (line 3, column 9):\n        states(first: 10, last: 10) { # too much pagination\n        ^",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorWithoutPagination.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorWithoutPagination.graphql
@@ -1,0 +1,14 @@
+query ListAllStatesOfDeposit {
+    deposit(id: "00000000-0000-0000-0000-000000000001") {
+        states { # no pagination
+            edges {
+                node {
+                    id
+                    label
+                    description
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorWithoutPagination.json
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/errorWithoutPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "You must provide a `first` or `last` value to properly paginate the `states` connection. (line 3, column 9):\n        states { # no pagination\n        ^",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByLabelAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByLabelAscending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states(orderBy: {field: LABEL, direction: ASC}) {
+        states(first: 10, orderBy: {field: LABEL, direction: ASC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByLabelDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByLabelDescending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states(orderBy: {field: LABEL, direction: DESC}) {
+        states(first: 10, orderBy: {field: LABEL, direction: DESC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states(orderBy: {field: TIMESTAMP, direction: ASC}) {
+        states(first: 10, orderBy: {field: TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/orderedByTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states(orderBy: {field: TIMESTAMP, direction: DESC}) {
+        states(first: 10, orderBy: {field: TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listAllStatesOfDeposit/plain.graphql
@@ -1,6 +1,6 @@
 query ListAllStatesOfDeposit {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states {
+        states(first: 10) {
             edges {
                 node {
                     id

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithContentTypeFilterAll/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithContentTypeFilterAll/plain.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000002") {
         contentType {
             value
-            deposits(contentTypeFilter: ALL) {
+            deposits(first: 10, contentTypeFilter: ALL) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithCuratorFilterAll/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithCuratorFilterAll/plain.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         curator {
             userId
-            deposits(curatorFilter: ALL) {
+            deposits(first: 10, curatorFilter: ALL) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithIngestStepFilterAll/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithIngestStepFilterAll/plain.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         ingestStep {
             step
-            deposits(ingestStepFilter: ALL) {
+            deposits(first: 10, ingestStepFilter: ALL) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByCreationTimestampAscending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000002") {
         contentType {
             value
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByCreationTimestampDescending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000002") {
         contentType {
             value
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByUserIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByUserIdAscending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000002") {
         contentType {
             value
-            deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByUserIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/orderedByUserIdDescending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000002") {
         contentType {
             value
-            deposits(orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameContentType/plain.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000002") {
         contentType {
             value
-            deposits {
+            deposits(first: 10) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByCreationTimestampAscending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         curator {
             userId
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByCreationTimestampDescending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         curator {
             userId
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByUserIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByUserIdAscending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         curator {
             userId
-            deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByUserIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/orderedByUserIdDescending.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         curator {
             userId
-            deposits(orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameCurator/plain.graphql
@@ -2,7 +2,7 @@ query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         curator {
             userId
-            deposits {
+            deposits(first: 10) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByCreationTimestampAscending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameDepositor {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         depositor {
             depositorId
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByCreationTimestampDescending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameDepositor {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         depositor {
             depositorId
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByDepositIdAscending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameDepositor {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         depositor {
             depositorId
-            deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/orderedByDepositIdDescending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameDepositor {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         depositor {
             depositorId
-            deposits(orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameDepositor/plain.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameDepositor {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         depositor {
             depositorId
-            deposits {
+            deposits(first: 10) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByCreationTimestampAscending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         ingestStep {
             step
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByCreationTimestampDescending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         ingestStep {
             step
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByDepositIdAscending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         ingestStep {
             step
-            deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/orderedByDepositIdDescending.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         ingestStep {
             step
-            deposits(orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameIngestStep/plain.graphql
@@ -2,7 +2,7 @@ query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         ingestStep {
             step
-            deposits {
+            deposits(first: 10) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByCreationTimestampAscending.graphql
@@ -1,7 +1,7 @@
 query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         state {
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByCreationTimestampDescending.graphql
@@ -1,7 +1,7 @@
 query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         state {
-            deposits(orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByDepositIdAscending.graphql
@@ -1,7 +1,7 @@
 query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         state {
-            deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/orderedByDepositIdDescending.graphql
@@ -1,7 +1,7 @@
 query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         state {
-            deposits(orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+            deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithSameState/plain.graphql
@@ -1,7 +1,7 @@
 query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         state {
-            deposits {
+            deposits(first: 10) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/listDepositsWithStateFilterAll/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/listDepositsWithStateFilterAll/plain.graphql
@@ -1,7 +1,7 @@
 query ListDepositsWithSameState {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
         state {
-            deposits(stateFilter: ALL) {
+            deposits(first: 10, stateFilter: ALL) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/deposit/nested.graphql
+++ b/src/test/resources/graphql-examples/deposit/nested.graphql
@@ -1,37 +1,37 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
-                states {
+                states(first: 10) {
                     edges {
                         node {
                             label
-                            deposits {
+                            deposits(first: 10) {
                                 edges {
                                     node {
                                         depositId
-                                        states {
+                                        states(first: 10) {
                                             edges {
                                                 node {
                                                     label
-                                                    deposits {
+                                                    deposits(first: 10) {
                                                         edges {
                                                             node {
                                                                 depositId
-                                                                states {
+                                                                states(first: 10) {
                                                                     edges {
                                                                         node {
                                                                             label
-                                                                            deposits {
+                                                                            deposits(first: 10) {
                                                                                 edges {
                                                                                     node {
                                                                                         depositId
-                                                                                        states {
+                                                                                        states(first: 10) {
                                                                                             edges {
                                                                                                 node {
                                                                                                     label
-                                                                                                    deposits {
+                                                                                                    deposits(first: 10) {
                                                                                                         edges {
                                                                                                             node {
                                                                                                                 depositId

--- a/src/test/resources/graphql-examples/deposit/register/alreadyExists.graphql
+++ b/src/test/resources/graphql-examples/deposit/register/alreadyExists.graphql
@@ -16,7 +16,7 @@ mutation RegisterDepositAlreadyExists {
                 depositorId
             }
             origin
-            states {
+            states(first: 10) {
                 edges {
                     node {
                         label
@@ -25,7 +25,7 @@ mutation RegisterDepositAlreadyExists {
                     }
                 }
             }
-            ingestSteps {
+            ingestSteps(first: 10) {
                 edges {
                     node {
                         step
@@ -48,7 +48,7 @@ mutation RegisterDepositAlreadyExists {
                 value
                 timestamp
             }
-            curators {
+            curators(first: 10) {
                 edges {
                     node {
                         userId

--- a/src/test/resources/graphql-examples/deposit/register/minimal.graphql
+++ b/src/test/resources/graphql-examples/deposit/register/minimal.graphql
@@ -16,7 +16,7 @@ mutation RegisterMinimal {
                 depositorId
             }
             origin
-            states {
+            states(first: 10) {
                 edges {
                     node {
                         label
@@ -25,7 +25,7 @@ mutation RegisterMinimal {
                     }
                 }
             }
-            ingestSteps {
+            ingestSteps(first: 10) {
                 edges {
                     node {
                         step
@@ -48,7 +48,7 @@ mutation RegisterMinimal {
                 value
                 timestamp
             }
-            curators {
+            curators(first: 10) {
                 edges {
                     node {
                         userId

--- a/src/test/resources/graphql-examples/deposit/register/missingCreationTimestamp.graphql
+++ b/src/test/resources/graphql-examples/deposit/register/missingCreationTimestamp.graphql
@@ -15,7 +15,7 @@ mutation RegisterMinimal {
                 depositorId
             }
             origin
-            states {
+            states(first: 10) {
                 edges {
                     node {
                         label
@@ -24,7 +24,7 @@ mutation RegisterMinimal {
                     }
                 }
             }
-            ingestSteps {
+            ingestSteps(first: 10) {
                 edges {
                     node {
                         step
@@ -47,7 +47,7 @@ mutation RegisterMinimal {
                 value
                 timestamp
             }
-            curators {
+            curators(first: 10) {
                 edges {
                     node {
                         userId

--- a/src/test/resources/graphql-examples/deposit/register/missingMandatory.graphql
+++ b/src/test/resources/graphql-examples/deposit/register/missingMandatory.graphql
@@ -14,7 +14,7 @@ mutation RegisterMinimal {
                 depositorId
             }
             origin
-            states {
+            states(first: 10) {
                 edges {
                     node {
                         label
@@ -23,7 +23,7 @@ mutation RegisterMinimal {
                     }
                 }
             }
-            ingestSteps {
+            ingestSteps(first: 10) {
                 edges {
                     node {
                         step
@@ -46,7 +46,7 @@ mutation RegisterMinimal {
                 value
                 timestamp
             }
-            curators {
+            curators(first: 10) {
                 edges {
                     node {
                         userId

--- a/src/test/resources/graphql-examples/deposit/register/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/register/plain.graphql
@@ -35,7 +35,7 @@ mutation RegisterDeposit {
                 depositorId
             }
             origin
-            states {
+            states(first: 10) {
                 edges {
                     node {
                         label
@@ -44,7 +44,7 @@ mutation RegisterDeposit {
                     }
                 }
             }
-            ingestSteps {
+            ingestSteps(first: 10) {
                 edges {
                     node {
                         step
@@ -67,7 +67,7 @@ mutation RegisterDeposit {
                 value
                 timestamp
             }
-            curators {
+            curators(first: 10) {
                 edges {
                     node {
                         userId

--- a/src/test/resources/graphql-examples/deposit/timebasedSearch/earlierThanWithAtTimestamp.graphql
+++ b/src/test/resources/graphql-examples/deposit/timebasedSearch/earlierThanWithAtTimestamp.graphql
@@ -1,6 +1,6 @@
 query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states(earlierThan: "2019-01-01T04:00:00.000Z", atTimestamp: "2019-01-01T02:00:00.000Z") {
+        states(first: 10, earlierThan: "2019-01-01T04:00:00.000Z", atTimestamp: "2019-01-01T02:00:00.000Z") {
             edges {
                 node {
                     label

--- a/src/test/resources/graphql-examples/deposit/timebasedSearch/earlierThanWithAtTimestampOnEmptyList.graphql
+++ b/src/test/resources/graphql-examples/deposit/timebasedSearch/earlierThanWithAtTimestampOnEmptyList.graphql
@@ -1,6 +1,6 @@
 query {
     deposit(id: "00000000-0000-0000-0000-000000000002") {
-        curators(earlierThan: "2019-01-01T04:00:00.000Z", atTimestamp: "2019-01-01T02:00:00.000Z") {
+        curators(first: 10, earlierThan: "2019-01-01T04:00:00.000Z", atTimestamp: "2019-01-01T02:00:00.000Z") {
             edges {
                 node {
                     userId

--- a/src/test/resources/graphql-examples/deposit/timebasedSearch/plain.graphql
+++ b/src/test/resources/graphql-examples/deposit/timebasedSearch/plain.graphql
@@ -1,6 +1,6 @@
 query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states1: states(earlierThan: "2019-01-01T04:00:00.000Z", laterThan: "2019-01-01T02:00:00.000Z") {
+        states1: states(first: 10, earlierThan: "2019-01-01T04:00:00.000Z", laterThan: "2019-01-01T02:00:00.000Z") {
             edges {
                 node {
                     label
@@ -9,7 +9,7 @@ query {
                 }
             }
         }
-        states2: states(earlierThan: "2019-01-01T02:00:00.000Z", laterThan: "2019-01-01T04:00:00.000Z") {
+        states2: states(first: 10, earlierThan: "2019-01-01T02:00:00.000Z", laterThan: "2019-01-01T04:00:00.000Z") {
             edges {
                 node {
                     label
@@ -18,7 +18,7 @@ query {
                 }
             }
         }
-        states3: states(atTimestamp: "2019-01-01T04:04:00.000Z") {
+        states3: states(first: 10, atTimestamp: "2019-01-01T04:04:00.000Z") {
             edges {
                 node {
                     label
@@ -27,7 +27,7 @@ query {
                 }
             }
         }
-        ingestSteps(earlierThan: "2019-01-01T04:07:00.000Z") {
+        ingestSteps(first: 10, earlierThan: "2019-01-01T04:07:00.000Z") {
             edges {
                 node {
                     step
@@ -35,7 +35,7 @@ query {
                 }
             }
         }
-        curators(laterThan: "2019-01-01T02:00:00.000Z") {
+        curators(first: 10, laterThan: "2019-01-01T02:00:00.000Z") {
             edges {
                 node {
                     userId

--- a/src/test/resources/graphql-examples/deposit/timebasedSearch/sameEarlierThanAndLaterThan.graphql
+++ b/src/test/resources/graphql-examples/deposit/timebasedSearch/sameEarlierThanAndLaterThan.graphql
@@ -1,6 +1,6 @@
 query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states(earlierThan: "2019-01-01T04:00:00.000Z", laterThan: "2019-01-01T04:00:00.000Z") {
+        states(first: 10, earlierThan: "2019-01-01T04:00:00.000Z", laterThan: "2019-01-01T04:00:00.000Z") {
             edges {
                 node {
                     label

--- a/src/test/resources/graphql-examples/deposit/timebasedSearch/sameEarlierThanAndLaterThanDifferentTimezone.graphql
+++ b/src/test/resources/graphql-examples/deposit/timebasedSearch/sameEarlierThanAndLaterThanDifferentTimezone.graphql
@@ -1,6 +1,6 @@
 query {
     deposit(id: "00000000-0000-0000-0000-000000000001") {
-        states(earlierThan: "2019-01-01T04:00:00.000Z", laterThan: "2019-01-01T06:00:00.000+02:00") {
+        states(first: 10, earlierThan: "2019-01-01T04:00:00.000Z", laterThan: "2019-01-01T06:00:00.000+02:00") {
             edges {
                 node {
                     label

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithBagNameAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithBagNameAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user002") {
-        deposits(bagName: "bag3") {
+        deposits(first: 10, bagName: "bag3") {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(contentType: {value: ZIP}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, contentType: {value: ZIP}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(contentType: {value: ZIP}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, contentType: {value: ZIP}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(contentType: {value: ZIP}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, contentType: {value: ZIP}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(contentType: {value: ZIP}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, contentType: {value: ZIP}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithContentTypeAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(contentType: {value: ZIP}) {
+        deposits(first: 10, contentType: {value: ZIP}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationPerformedAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationPerformed: {value: true, filter: LATEST}) {
+        deposits(first: 10, curationPerformed: {value: true, filter: LATEST}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCurationRequiredAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curationRequired: {value: true, filter: LATEST}) {
+        deposits(first: 10, curationRequired: {value: true, filter: LATEST}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curator: {userId: "archie001"}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, curator: {userId: "archie001"}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curator: {userId: "archie001"}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, curator: {userId: "archie001"}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curator: {userId: "archie001"}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, curator: {userId: "archie001"}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curator: {userId: "archie001"}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, curator: {userId: "archie001"}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithCuratorAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(curator: {userId: "archie001"}) {
+        deposits(first: 10, curator: {userId: "archie001"}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsFromDepositor {
     depositor(id: "user002") {
-        deposits(orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsFromDepositor {
     depositor(id: "user002") {
-        deposits(orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsFromDepositor {
     depositor(id: "user002") {
-        deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsFromDepositor {
     depositor(id: "user002") {
-        deposits(orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query ListDepositsFromDepositor {
     depositor(id: "user002") {
-        deposits {
+        deposits(first: 10) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiActionAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiAction: {value: CREATE, filter: LATEST}) {
+        deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithDoiRegisteredAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(doiRegistered: {value: true, filter: LATEST}) {
+        deposits(first: 10, doiRegistered: {value: true, filter: LATEST}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithIngestStepAndDepositor {
     depositor(id: "user001") {
-        deposits(ingestStep: {label: COMPLETED}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, ingestStep: {label: COMPLETED}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithIngestStepAndDepositor {
     depositor(id: "user001") {
-        deposits(ingestStep: {label: COMPLETED}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, ingestStep: {label: COMPLETED}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithIngestStepAndDepositor {
     depositor(id: "user001") {
-        deposits(ingestStep: {label: COMPLETED}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, ingestStep: {label: COMPLETED}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithIngestStepAndDepositor {
     depositor(id: "user001") {
-        deposits(ingestStep: {label: COMPLETED}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, ingestStep: {label: COMPLETED}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIngestStepAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithIngestStepAndDepositor {
     depositor(id: "user001") {
-        deposits(ingestStep: {label: COMPLETED}) {
+        deposits(first: 10, ingestStep: {label: COMPLETED}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithIsNewVersionAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query {
     depositor(id: "user001") {
-        deposits(isNewVersion: {value: false, filter: LATEST}) {
+        deposits(first: 10, isNewVersion: {value: false, filter: LATEST}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByCreationTimestampAscending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithStateAndDepositor {
     depositor(id: "user001") {
-        deposits(state: {label: ARCHIVED}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+        deposits(first: 10, state: {label: ARCHIVED}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
             edges {
                 node {
                     creationTimestamp

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByCreationTimestampDescending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithStateAndDepositor {
     depositor(id: "user001") {
-        deposits(state: {label: ARCHIVED}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+        deposits(first: 10, state: {label: ARCHIVED}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
             edges {
                 node {
                     creationTimestamp

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByDepositIdAscending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithStateAndDepositor {
     depositor(id: "user001") {
-        deposits(state: {label: ARCHIVED}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+        deposits(first: 10, state: {label: ARCHIVED}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
             edges {
                 node {
                     creationTimestamp

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/orderedByDepositIdDescending.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithStateAndDepositor {
     depositor(id: "user001") {
-        deposits(state: {label: ARCHIVED}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+        deposits(first: 10, state: {label: ARCHIVED}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
             edges {
                 node {
                     creationTimestamp

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithStateAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithStateAndDepositor {
     depositor(id: "user001") {
-        deposits(state: {label: ARCHIVED}) {
+        deposits(first: 10, state: {label: ARCHIVED}) {
             edges {
                 node {
                     creationTimestamp

--- a/src/test/resources/graphql-examples/depositor/listDepositsWithStateFilterAllAndDepositor/plain.graphql
+++ b/src/test/resources/graphql-examples/depositor/listDepositsWithStateFilterAllAndDepositor/plain.graphql
@@ -1,6 +1,6 @@
 query ListDepositsWithStateAndDepositor {
     depositor(id: "user001") {
-        deposits(state: {label: DRAFT, filter: ALL}) {
+        deposits(first: 10, state: {label: DRAFT, filter: ALL}) {
             edges {
                 node {
                     depositId

--- a/src/test/resources/graphql-examples/depositors/histogram/plain.graphql
+++ b/src/test/resources/graphql-examples/depositors/histogram/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    depositors {
+    depositors(first: 10) {
         edges {
             node {
                 depositorId

--- a/src/test/resources/graphql-examples/depositors/listDepositors/plain.graphql
+++ b/src/test/resources/graphql-examples/depositors/listDepositors/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    depositors {
+    depositors(first: 10) {
         edges {
             node {
                 depositorId

--- a/src/test/resources/graphql-examples/depositors/listSMDDepositorsWithArchivedDeposits/plain.graphql
+++ b/src/test/resources/graphql-examples/depositors/listSMDDepositorsWithArchivedDeposits/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    depositors(origin: SMD, state: {label: ARCHIVED, filter: LATEST}) {
+    depositors(first: 10, origin: SMD, state: {label: ARCHIVED, filter: LATEST}) {
         edges {
             node {
                 depositorId

--- a/src/test/resources/graphql-examples/depositors/listSwordDepositors/plain.graphql
+++ b/src/test/resources/graphql-examples/depositors/listSwordDepositors/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    depositors(origin: SWORD2) {
+    depositors(first: 10, origin: SWORD2) {
         edges {
             node {
                 depositorId

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/errorBothFirstAndLastInPagination.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/errorBothFirstAndLastInPagination.graphql
@@ -1,0 +1,92 @@
+query ListAllDeposits {
+    deposits(first: 10, last: 10) { # too much pagination
+        edges {
+            node {
+                depositId
+                depositor {
+                    depositorId
+                }
+                bagName
+                origin
+                creationTimestamp
+                lastModified
+                state {
+                    label
+                    description
+                    timestamp
+                }
+                ingestStep {
+                    step
+                    timestamp
+                }
+                identifiers {
+                    id
+                    type
+                    value
+                    timestamp
+                }
+                doiRegistered
+                doiRegisteredEvents {
+                    value
+                    timestamp
+                }
+                doiAction
+                doiActionEvents {
+                    value
+                    timestamp
+                }
+                curator {
+                    userId
+                    email
+                    timestamp
+                }
+                curators(first: 10) {
+                    edges {
+                        node {
+                            userId
+                            email
+                            timestamp
+                        }
+                    }
+                }
+                isNewVersion
+                isNewVersionEvents {
+                    value
+                    timestamp
+                }
+                curationRequired
+                curationRequiredEvents {
+                    value
+                    timestamp
+                }
+                curationPerformed
+                curationPerformedEvents {
+                    value
+                    timestamp
+                }
+                springfield {
+                    domain
+                    user
+                    collection
+                    playmode
+                    timestamp
+                }
+                springfields {
+                    domain
+                    user
+                    collection
+                    playmode
+                    timestamp
+                }
+                contentType {
+                    value
+                    timestamp
+                }
+                contentTypes {
+                    value
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/errorBothFirstAndLastInPagination.json
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/errorBothFirstAndLastInPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Passing both `first` and `last` to paginate the `deposits` connection is not supported. (line 2, column 5):\n    deposits(first: 10, last: 10) { # too much pagination\n    ^",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/errorWithoutPagination.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/errorWithoutPagination.graphql
@@ -1,0 +1,92 @@
+query ListAllDeposits {
+    deposits { # no pagination
+        edges {
+            node {
+                depositId
+                depositor {
+                    depositorId
+                }
+                bagName
+                origin
+                creationTimestamp
+                lastModified
+                state {
+                    label
+                    description
+                    timestamp
+                }
+                ingestStep {
+                    step
+                    timestamp
+                }
+                identifiers {
+                    id
+                    type
+                    value
+                    timestamp
+                }
+                doiRegistered
+                doiRegisteredEvents {
+                    value
+                    timestamp
+                }
+                doiAction
+                doiActionEvents {
+                    value
+                    timestamp
+                }
+                curator {
+                    userId
+                    email
+                    timestamp
+                }
+                curators(first: 10) {
+                    edges {
+                        node {
+                            userId
+                            email
+                            timestamp
+                        }
+                    }
+                }
+                isNewVersion
+                isNewVersionEvents {
+                    value
+                    timestamp
+                }
+                curationRequired
+                curationRequiredEvents {
+                    value
+                    timestamp
+                }
+                curationPerformed
+                curationPerformedEvents {
+                    value
+                    timestamp
+                }
+                springfield {
+                    domain
+                    user
+                    collection
+                    playmode
+                    timestamp
+                }
+                springfields {
+                    domain
+                    user
+                    collection
+                    playmode
+                    timestamp
+                }
+                contentType {
+                    value
+                    timestamp
+                }
+                contentTypes {
+                    value
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/errorWithoutPagination.json
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/errorWithoutPagination.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "You must provide a `first` or `last` value to properly paginate the `deposits` connection. (line 2, column 5):\n    deposits { # no pagination\n    ^",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByBagNameAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByBagNameAscending.graphql
@@ -1,5 +1,5 @@
 query ListAllDepositsOrderedByBagNameAscending {
-    deposits(orderBy: {field: BAG_NAME, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: BAG_NAME, direction: ASC}) {
         edges {
             node {
                 depositId
@@ -40,7 +40,7 @@ query ListAllDepositsOrderedByBagNameAscending {
                     email
                     timestamp
                 }
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByBagNameDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByBagNameDescending.graphql
@@ -1,5 +1,5 @@
 query ListAllDepositsOrderedByBagNameDescending {
-    deposits(orderBy: {field: BAG_NAME, direction: DESC}) {
+    deposits(first: 10, orderBy: {field: BAG_NAME, direction: DESC}) {
         edges {
             node {
                 depositId
@@ -40,7 +40,7 @@ query ListAllDepositsOrderedByBagNameDescending {
                     email
                     timestamp
                 }
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query ListAllDepositsOrderedByCreationTimestampAscending {
-    deposits(orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId
@@ -40,7 +40,7 @@ query ListAllDepositsOrderedByCreationTimestampAscending {
                     email
                     timestamp
                 }
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query ListAllDepositsOrderedByCreationTimestampDescending {
-    deposits(orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId
@@ -40,7 +40,7 @@ query ListAllDepositsOrderedByCreationTimestampDescending {
                     email
                     timestamp
                 }
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query ListAllDepositsOrderedByDepositIdAscending {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
@@ -40,7 +40,7 @@ query ListAllDepositsOrderedByDepositIdAscending {
                     email
                     timestamp
                 }
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query ListAllDepositsOrderedByDepositIdDescending {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId
@@ -40,7 +40,7 @@ query ListAllDepositsOrderedByDepositIdDescending {
                     email
                     timestamp
                 }
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDeposits/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDeposits/plain.graphql
@@ -1,5 +1,5 @@
 query ListAllDeposits {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
@@ -40,7 +40,7 @@ query ListAllDeposits {
                     email
                     timestamp
                 }
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByTimestampAscending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                curators(orderBy: {field: TIMESTAMP, direction: ASC}) {
+                curators(first: 10, orderBy: {field: TIMESTAMP, direction: ASC}) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByTimestampDescending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                curators(orderBy: {field: TIMESTAMP, direction: DESC}) {
+                curators(first: 10, orderBy: {field: TIMESTAMP, direction: DESC}) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByUserIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByUserIdAscending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                curators(orderBy: {field: USERID, direction: ASC}) {
+                curators(first: 10, orderBy: {field: USERID, direction: ASC}) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByUserIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/orderedByUserIdDescending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                curators(orderBy: {field: USERID, direction: DESC}) {
+                curators(first: 10, orderBy: {field: USERID, direction: DESC}) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllCurators/plain.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             userId

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByLabelAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByLabelAscending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                ingestSteps(orderBy: {field: STEP, direction: ASC}) {
+                ingestSteps(first: 10, orderBy: {field: STEP, direction: ASC}) {
                     edges {
                         node {
                             step

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByLabelDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByLabelDescending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                ingestSteps(orderBy: {field: STEP, direction: DESC}) {
+                ingestSteps(first: 10, orderBy: {field: STEP, direction: DESC}) {
                     edges {
                         node {
                             step

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByTimestampAscending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                ingestSteps(orderBy: {field: TIMESTAMP, direction: ASC}) {
+                ingestSteps(first: 10, orderBy: {field: TIMESTAMP, direction: ASC}) {
                     edges {
                         node {
                             step

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/orderedByTimestampDescending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                ingestSteps(orderBy: {field: TIMESTAMP, direction: DESC}) {
+                ingestSteps(first: 10, orderBy: {field: TIMESTAMP, direction: DESC}) {
                     edges {
                         node {
                             step

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllIngestSteps/plain.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                ingestSteps {
+                ingestSteps(first: 10) {
                     edges {
                         node {
                             step

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByLabelAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByLabelAscending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                states(orderBy: {field: LABEL, direction: ASC}) {
+                states(first: 10, orderBy: {field: LABEL, direction: ASC}) {
                     edges {
                         node {
                             label

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByLabelDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByLabelDescending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                states(orderBy: {field: LABEL, direction: DESC}) {
+                states(first: 10, orderBy: {field: LABEL, direction: DESC}) {
                     edges {
                         node {
                             label

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByTimestampAscending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                states(orderBy: {field: TIMESTAMP, direction: ASC}) {
+                states(first: 10, orderBy: {field: TIMESTAMP, direction: ASC}) {
                     edges {
                         node {
                             label

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/orderedByTimestampDescending.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                states(orderBy: {field: TIMESTAMP, direction: DESC}) {
+                states(first: 10, orderBy: {field: TIMESTAMP, direction: DESC}) {
                     edges {
                         node {
                             label

--- a/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listAllDepositsWithAllStates/plain.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits(orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId
-                states {
+                states(first: 10) {
                     edges {
                         node {
                             label

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithBagName/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithBagName/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(bagName: "bag3") {
+    deposits(first: 10, bagName: "bag3") {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(contentType: {value: ZIP, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, contentType: {value: ZIP, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(contentType: {value: ZIP, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, contentType: {value: ZIP, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(contentType: {value: ZIP, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, contentType: {value: ZIP, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(contentType: {value: ZIP, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, contentType: {value: ZIP, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithContentType/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(contentType: {value: ZIP, filter: LATEST}) {
+    deposits(first: 10, contentType: {value: ZIP, filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, curationPerformed: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationPerformed/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationPerformed: {value: true, filter: LATEST}) {
+    deposits(first: 10, curationPerformed: {value: true, filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, curationRequired: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurationRequired/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curationRequired: {value: true, filter: LATEST}) {
+    deposits(first: 10, curationRequired: {value: true, filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curator: {userId: "archie001", filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, curator: {userId: "archie001", filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curator: {userId: "archie001", filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, curator: {userId: "archie001", filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curator: {userId: "archie001", filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, curator: {userId: "archie001", filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curator: {userId: "archie001", filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, curator: {userId: "archie001", filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithCurator/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(curator: {userId: "archie001", filter: LATEST}) {
+    deposits(first: 10, curator: {userId: "archie001", filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiAction/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiAction: {value: CREATE, filter: LATEST}) {
+    deposits(first: 10, doiAction: {value: CREATE, filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, doiRegistered: {value: true, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithDoiRegistered/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(doiRegistered: {value: true, filter: LATEST}) {
+    deposits(first: 10, doiRegistered: {value: true, filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithIngestStepFilterAll/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithIngestStepFilterAll/plain.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(ingestStep: {label: VALIDATE, filter: ALL}) {
+    deposits(first: 10, ingestStep: {label: VALIDATE, filter: ALL}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, isNewVersion: {value: false, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithIsNewVersion/plain.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits(isNewVersion: {value: false, filter: LATEST}) {
+    deposits(first: 10, isNewVersion: {value: false, filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByCreationTimestampAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByCreationTimestampAscending.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
+    deposits(first: 10, state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByCreationTimestampDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByCreationTimestampDescending.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
+    deposits(first: 10, state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: CREATION_TIMESTAMP, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByDepositIdAscending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByDepositIdAscending.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+    deposits(first: 10, state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByDepositIdDescending.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithState/orderedByDepositIdDescending.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
+    deposits(first: 10, state: {label: ARCHIVED, filter: LATEST}, orderBy: {field: DEPOSIT_ID, direction: DESC}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithState/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithState/plain.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(state: {label: ARCHIVED, filter: LATEST}) {
+    deposits(first: 10, state: {label: ARCHIVED, filter: LATEST}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithStateFilterAll/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithStateFilterAll/plain.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(state: {label: DRAFT, filter: ALL}) {
+    deposits(first: 10, state: {label: DRAFT, filter: ALL}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/listDepositsWithStateFilterAllAndIngestStepFilterAll/plain.graphql
+++ b/src/test/resources/graphql-examples/deposits/listDepositsWithStateFilterAllAndIngestStepFilterAll/plain.graphql
@@ -1,5 +1,5 @@
 query ListDepositsWithState {
-    deposits(state: {label: REJECTED, filter: ALL}, ingestStep: {label: VALIDATE, filter: ALL}) {
+    deposits(first: 10, state: {label: REJECTED, filter: ALL}, ingestStep: {label: VALIDATE, filter: ALL}) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaContentType.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaContentType.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaContentTypes.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaContentTypes.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaCurator.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaCurator.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaCurators.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaCurators.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             id

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIdentifier.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIdentifier.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIdentifiers.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIdentifiers.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIngestStep.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIngestStep.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIngestSteps.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaIngestSteps.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
-                ingestSteps {
+                ingestSteps(first: 10) {
                     edges {
                         node {
                             id

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaSpringfield.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaSpringfield.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaSpringfields.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaSpringfields.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaState.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaState.graphql
@@ -1,5 +1,5 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaStates.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposit/viaStates.graphql
@@ -1,9 +1,9 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
-                states {
+                states(first: 10) {
                     edges {
                         node {
                             id

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaContentType.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaContentType.graphql
@@ -1,11 +1,11 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
                 contentType {
                     id
-                    deposits {
+                    deposits(first: 10) {
                         edges {
                             node {
                                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaContentTypes.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaContentTypes.graphql
@@ -1,11 +1,11 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
                 contentTypes {
                     id
-                    deposits {
+                    deposits(first: 10) {
                         edges {
                             node {
                                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaCurator.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaCurator.graphql
@@ -1,11 +1,11 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
                 curator {
                     id
-                    deposits {
+                    deposits(first: 10) {
                         edges {
                             node {
                                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaCurators.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaCurators.graphql
@@ -1,13 +1,13 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
-                curators {
+                curators(first: 10) {
                     edges {
                         node {
                             id
-                            deposits {
+                            deposits(first: 10) {
                                 edges {
                                     node {
                                         depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaIngestStep.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaIngestStep.graphql
@@ -1,11 +1,11 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
                 ingestStep {
                     id
-                    deposits {
+                    deposits(first: 10) {
                         edges {
                             node {
                                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaIngestSteps.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaIngestSteps.graphql
@@ -1,13 +1,13 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
-                ingestSteps {
+                ingestSteps(first: 10) {
                     edges {
                         node {
                             id
-                            deposits {
+                            deposits(first: 10) {
                                 edges {
                                     node {
                                         depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaState.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaState.graphql
@@ -1,11 +1,11 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
                 state {
                     id
-                    deposits {
+                    deposits(first: 10) {
                         edges {
                             node {
                                 depositId

--- a/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaStates.graphql
+++ b/src/test/resources/graphql-examples/deposits/nestedDeposits/deposits/viaStates.graphql
@@ -1,13 +1,13 @@
 query {
-    deposits {
+    deposits(first: 10) {
         edges {
             node {
                 depositId
-                states {
+                states(first: 10) {
                     edges {
                         node {
                             id
-                            deposits {
+                            deposits(first: 10) {
                                 edges {
                                     node {
                                         depositId

--- a/src/test/resources/graphql-examples/node/onContentType.graphql
+++ b/src/test/resources/graphql-examples/node/onContentType.graphql
@@ -6,7 +6,7 @@ query {
             deposit {
                 depositId
             }
-            deposits(contentTypeFilter: ALL, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, contentTypeFilter: ALL, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/node/onCurator.graphql
+++ b/src/test/resources/graphql-examples/node/onCurator.graphql
@@ -7,7 +7,7 @@ query {
             deposit {
                 depositId
             }
-            deposits(curatorFilter: ALL, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, curatorFilter: ALL, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/node/onIngestStep.graphql
+++ b/src/test/resources/graphql-examples/node/onIngestStep.graphql
@@ -6,7 +6,7 @@ query {
             deposit {
                 depositId
             }
-            deposits(ingestStepFilter: ALL, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
+            deposits(first: 10, ingestStepFilter: ALL, orderBy: {field: DEPOSIT_ID, direction: ASC}) {
                 edges {
                     node {
                         depositId

--- a/src/test/resources/graphql-examples/node/onState.graphql
+++ b/src/test/resources/graphql-examples/node/onState.graphql
@@ -8,7 +8,7 @@ query {
             deposit {
                 depositId
             }
-            deposits(stateFilter: ALL) {
+            deposits(first: 10, stateFilter: ALL) {
                 edges {
                     node {
                         id

--- a/src/test/scala/nl.knaw.dans.easy.properties/server/GraphQLExamplesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/server/GraphQLExamplesSpec.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.properties.server
 
 import better.files.File
 import nl.knaw.dans.easy.properties.app.graphql.middleware.Authentication.Auth
-import nl.knaw.dans.easy.properties.fixture.{ DatabaseDataFixture, DatabaseFixture, FileSystemSupport, FixedCurrentDateTimeSupport, TestSupportFixture }
+import nl.knaw.dans.easy.properties.fixture._
 import org.json4s.JsonAST.JNull
 import org.json4s.JsonDSL._
 import org.json4s.ext.UUIDSerializer
@@ -74,7 +74,10 @@ class GraphQLExamplesSpec extends TestSupportFixture
 
         post(uri = "/", body = inputBody.getBytes, headers = Seq(authHeader)) {
           body shouldBe expectedOutput
-          status shouldBe 200
+          if (graphQLExample.name startsWith "error")
+            status shouldBe 400
+          else
+            status shouldBe 200
         }
       }
     }


### PR DESCRIPTION
~Fixes EASY-~

#### When applied it will
* implement query validation for Relay's pagination (you know, `edges` and `node` kinda stuff), making sure that either a `first` or `last` argument is present
* adjust loads of examples to this new validation
* include some new examples to test this extra validation

#### Examples
**Valid (1):**
```graphql
query {
    deposit(id: "00000000-0000-0000-0000-000000000001") {
        curators(first: 10) {
            edges {
                node {
                    userId
                    email
                    timestamp
                }
            }
        }
    }
}
```

**Valid (2):**
```graphql
query {
    deposit(id: "00000000-0000-0000-0000-000000000001") {
        curators(last: 10) {
            edges {
                node {
                    userId
                    email
                    timestamp
                }
            }
        }
    }
}
```

**Not valid (1):**
```graphql
query {
    deposit(id: "00000000-0000-0000-0000-000000000001") {
        curators { # no pagination parameters
            edges {
                node {
                    userId
                    email
                    timestamp
                }
            }
        }
    }
}
```

**Not valid (2):**
```graphql
query {
    deposit(id: "00000000-0000-0000-0000-000000000001") {
        curators(first: 10, last: 10) { # both first and last are provided
            edges {
                node {
                    userId
                    email
                    timestamp
                }
            }
        }
    }
}
```

@DANS-KNAW/easy for review