### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,6 @@
         <sangria-relay.version>2.0.0-M2</sangria-relay.version>
         <sangria.version>2.0.0-M3</sangria.version>
         <sangria-json4s-native.version>1.0.1</sangria-json4s-native.version>
-
-        <!-- xml -->
-        <jakarta-xml-bind.version>3.0.0-RC1</jakarta-xml-bind.version>
-        <jaxb-runtime.version>2.4.0-b180830.0438</jaxb-runtime.version>
     </properties>
 
     <scm>
@@ -159,18 +155,6 @@
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria-slowlog_2.12</artifactId>
             <version>${sangria-slowlog.version}</version>
-        </dependency>
-
-        <!-- xml -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta-xml-bind.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>${jaxb-runtime.version}</version>
         </dependency>
 
         <!-- json -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,16 @@
     <properties>
         <main-class>nl.knaw.dans.easy.properties.Command</main-class>
         <easy.datacite.version>3.10.4</easy.datacite.version>
+
+        <!-- graphql -->
+        <sangria-slowlog.version>2.0.0-M1</sangria-slowlog.version>
+        <sangria-relay.version>2.0.0-M2</sangria-relay.version>
+        <sangria.version>2.0.0-M3</sangria.version>
+        <sangria-json4s-native.version>1.0.1</sangria-json4s-native.version>
+
+        <!-- xml -->
+        <jakarta-xml-bind.version>3.0.0-RC1</jakarta-xml-bind.version>
+        <jaxb-runtime.version>2.4.0-b180830.0438</jaxb-runtime.version>
     </properties>
 
     <scm>
@@ -133,34 +143,34 @@
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria_2.12</artifactId>
-            <version>2.0.0-M3</version>
+            <version>${sangria.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria-relay_2.12</artifactId>
-            <version>2.0.0-M2</version>
+            <version>${sangria-relay.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria-json4s-native_2.12</artifactId>
-            <version>1.0.1</version>
+            <version>${sangria-json4s-native.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria-slowlog_2.12</artifactId>
-            <version>2.0.0-M1</version>
+            <version>${sangria-slowlog.version}</version>
         </dependency>
 
         <!-- xml -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>3.0.0-RC1</version>
+            <version>${jakarta-xml-bind.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.4.0-b180830.0438</version>
+            <version>${jaxb-runtime.version}</version>
         </dependency>
 
         <!-- json -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.12</artifactId>
-            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
@@ -96,7 +95,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.1</version>
         </dependency>
 
         <!-- Apache Commons -->
@@ -129,29 +127,40 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
         </dependency>
 
         <!-- graphql -->
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria_2.12</artifactId>
-            <version>1.4.2</version>
+            <version>2.0.0-M3</version>
         </dependency>
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria-relay_2.12</artifactId>
-            <version>1.4.2</version>
+            <version>2.0.0-M2</version>
         </dependency>
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria-json4s-native_2.12</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.sangria-graphql</groupId>
             <artifactId>sangria-slowlog_2.12</artifactId>
-            <version>0.1.8</version>
+            <version>2.0.0-M1</version>
+        </dependency>
+
+        <!-- xml -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.0-RC1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.4.0-b180830.0438</version>
         </dependency>
 
         <!-- json -->
@@ -178,7 +187,6 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.4.1</version>
         </dependency>
 
         <!-- joda -->

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/relay/ExtendedConnectionLike.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/relay/ExtendedConnectionLike.scala
@@ -21,7 +21,7 @@ import scala.annotation.implicitNotFound
 import scala.language.higherKinds
 
 @implicitNotFound("Type ${T} can't be used as a ExtendedConnection. Please consider defining implicit instance of nl.dans.knaw.easy.properties.app.relay.ExtendedConnectionLike for type ${T} or extending nl.dans.knaw.easy.properties.app.relay.ExtendedConnection trait.")
-private[relay] trait ExtendedConnectionLike[T[_], Val, E <: Edge[Val]] extends ConnectionLike[T, Val, E] {
+private[relay] trait ExtendedConnectionLike[T[_], Val, E <: Edge[Val]] extends ConnectionLike[T, PageInfo, Val, E] {
   def totalCount(conn: T[Val]): Int
 }
 
@@ -34,6 +34,6 @@ private[relay] object ExtendedConnectionLike {
     override def totalCount(conn: ExtendedConnection[Any]): Int = conn.totalCount
   }
 
-  implicit def extendedConnectionIsExtendedConnectionLike[E <: Edge[Val], Val, T[_]]: ExtendedConnectionLike[T, Val, E] =
+  implicit def extendedConnectionIsExtendedConnectionLike[E <: Edge[Val], P <: PageInfo, Val, T[_]]: ExtendedConnectionLike[T, Val, E] =
     ExtendedConnectionIsExtendedConnectionLike.asInstanceOf[ExtendedConnectionLike[T, Val, E]]
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/register/DepositPropertiesImporter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/register/DepositPropertiesImporter.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.properties.app.register
 
-import better.files.StringOps
+import better.files.StringExtensions
 import cats.instances.either._
 import cats.instances.list._
 import cats.instances.option._

--- a/src/main/scala/nl.knaw.dans.easy.properties/server/EasyDepositPropertiesService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/server/EasyDepositPropertiesService.scala
@@ -39,10 +39,10 @@ class EasyDepositPropertiesService(serverPort: Int,
                   for ((path, servlet) <- servlets)
                     context.mount(servlet, path)
 
-                  context.initParameters(AllowedOriginsKey) = "*"
-                  context.initParameters(AllowedMethodsKey) = "GET,POST,HEAD"
-                  context.initParameters(AllowedHeadersKey) = "Content-Type,Accept,Authorization"
-                  context.initParameters(AllowCredentialsKey) = "true"
+                  context.setInitParameter(AllowedOriginsKey, "*")
+                  context.setInitParameter(AllowedMethodsKey, "GET,POST,HEAD")
+                  context.setInitParameter(AllowedHeadersKey, "Content-Type,Accept,Authorization")
+                  context.setInitParameter(AllowCredentialsKey, "true")
                 }
               })
             }

--- a/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
@@ -29,10 +29,10 @@ import nl.knaw.dans.easy.properties.app.repository.{ DepositFilters, DepositorId
 import org.joda.time.DateTime
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{ Arbitrary, Gen }
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{ Matchers, PropSpec }
 
-class QueryGeneratorPropSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class QueryGeneratorPropSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
 
   def genFromEnum[E <: Enumeration](enum: E): Arbitrary[E#Value] = Arbitrary {
     Gen.oneOf(enum.values.toList)


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* move unique dependency versions that aren't included in a parent POM to properties

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
