### PR TITLE
EASY-2179: update scalatra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>
@@ -79,6 +79,11 @@
         <dependency>
             <groupId>org.scalacheck</groupId>
             <artifactId>scalacheck_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>scalatestplus-scalacheck_2.12</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Scala utils -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.0.2</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/test/scala/nl.knaw.dans.easy.properties/DebugConfigSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/DebugConfigSpec.scala
@@ -17,11 +17,12 @@ package nl.knaw.dans.easy.properties
 
 import better.files.File
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 
-class DebugConfigSpec extends FlatSpec with Matchers {
+class DebugConfigSpec extends AnyFlatSpec with Matchers {
 
   val configDir = File("src/main/assembly/dist/cfg")
   val debugConfigDir = File("src/test/resources/debug-config")

--- a/src/test/scala/nl.knaw.dans.easy.properties/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/ReadmeSpec.scala
@@ -22,12 +22,13 @@ import nl.knaw.dans.easy.DataciteServiceConfiguration
 import nl.knaw.dans.easy.properties.app.database.DatabaseConfiguration
 import nl.knaw.dans.easy.properties.app.graphql.middleware.Authentication.Auth
 import nl.knaw.dans.easy.properties.fixture.CustomMatchers
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
+class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   private val configuration = Configuration(
     version = "my-version",

--- a/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/app/repository/sql/QueryGeneratorPropSpec.scala
@@ -29,10 +29,11 @@ import nl.knaw.dans.easy.properties.app.repository.{ DepositFilters, DepositorId
 import org.joda.time.DateTime
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{ Arbitrary, Gen }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{ Matchers, PropSpec }
 
-class QueryGeneratorPropSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class QueryGeneratorPropSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
 
   def genFromEnum[E <: Enumeration](enum: E): Arbitrary[E#Value] = Arbitrary {
     Gen.oneOf(enum.values.toList)

--- a/src/test/scala/nl.knaw.dans.easy.properties/fixture/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.properties/fixture/TestSupportFixture.scala
@@ -15,9 +15,11 @@
  */
 package nl.knaw.dans.easy.properties.fixture
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{ EitherValues, Inside, Inspectors, OptionValues }
 
-trait TestSupportFixture extends FlatSpec
+trait TestSupportFixture extends AnyFlatSpec
   with Matchers
   with Inside
   with OptionValues


### PR DESCRIPTION
fixes EASY-2179

#### When applied it will
* update parent POM version
* fix deprecation warnings
* add dependency `scalatestplus-scalacheck_2.12` to fix scalatest migration issues

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | Note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     |