### PR TITLE
remove unnecessary Option parameters from GraphQL interface

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -78,7 +78,7 @@ type ContentType implements Node {
   """
   Returns the deposit that is associated with this particular content type.
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """List all deposits with the same current content type."""
   deposits(
@@ -146,7 +146,7 @@ type Curator implements Node {
   """
   Returns the deposit that is associated with this particular curator object.
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """List all deposits with the same data manager."""
   deposits(
@@ -792,7 +792,7 @@ type Identifier implements Node {
   """
   Returns the deposit that is associated with this particular identifier.
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """The ID of an object"""
   id: ID!
@@ -824,7 +824,7 @@ type IngestStep implements Node {
   """
   Returns the deposit that is associated with this particular ingest step.
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """List all deposits with the same current ingest step."""
   deposits(
@@ -936,7 +936,7 @@ type IsCurationPerformed implements Node {
   """
   Returns the deposit that is associated with this particular IsCurationPerformedEvent
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """
   List all deposits with the same current IsCurationPerformedEvent value.
@@ -988,7 +988,7 @@ type IsCurationRequired implements Node {
   """
   Returns the deposit that is associated with this particular IsCurationRequiredEvent
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """List all deposits with the same current IsCurationRequiredEvent value."""
   deposits(
@@ -1038,7 +1038,7 @@ type IsNewVersion implements Node {
   """
   Returns the deposit that is associated with this particular IsNewVersionEvent
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """List all deposits with the same current IsNewVersion value."""
   deposits(
@@ -1309,7 +1309,7 @@ type Query {
 
     """The value of the identifier to be found."""
     value: String!
-  ): Identifier
+  ): Identifier!
 
   """Fetches an object given its ID"""
   node(
@@ -1548,7 +1548,7 @@ type Springfield implements Node {
   """
   Returns the deposit that is associated with this particular springfield configuration.
   """
-  deposit: Deposit
+  deposit: Deposit!
 
   """The ID of an object"""
   id: ID!
@@ -1590,7 +1590,7 @@ type State implements Node {
   timestamp: DateTime!
 
   """Returns the deposit that is associated with this particular state"""
-  deposit: Deposit
+  deposit: Deposit!
 
   """List all deposits with the same current state label."""
   deposits(

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLContentType.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLContentType.scala
@@ -44,9 +44,9 @@ class GraphQLContentType(contentType: ContentType) extends Node {
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular content type.")
-  def deposit(implicit ctx: Context[DataContext, GraphQLContentType]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLContentType]): DeferredValue[DataContext, GraphQLDeposit] = {
     ContentTypeResolver.depositByContentTypeId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 
   @GraphQLField

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLCurationPerformed.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLCurationPerformed.scala
@@ -44,9 +44,9 @@ class GraphQLCurationPerformed(curationPerformed: IsCurationPerformed) extends N
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular IsCurationPerformedEvent")
-  def deposit(implicit ctx: Context[DataContext, GraphQLCurationPerformed]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLCurationPerformed]): DeferredValue[DataContext, GraphQLDeposit] = {
     IsCurationPerformedResolver.depositByIsCurationPerformedId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 
   @GraphQLField

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLCurationRequired.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLCurationRequired.scala
@@ -44,9 +44,9 @@ class GraphQLCurationRequired(curationRequired: IsCurationRequired) extends Node
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular IsCurationRequiredEvent")
-  def deposit(implicit ctx: Context[DataContext, GraphQLCurationRequired]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLCurationRequired]): DeferredValue[DataContext, GraphQLDeposit] = {
     IsCurationRequiredResolver.depositByIsCurationRequiredId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 
   @GraphQLField

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLCurator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLCurator.scala
@@ -55,9 +55,9 @@ class GraphQLCurator(curator: Curator) extends Node {
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular curator object.")
-  def deposit(implicit ctx: Context[DataContext, GraphQLCurator]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLCurator]): DeferredValue[DataContext, GraphQLDeposit] = {
     CuratorResolver.depositByCuratorId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 
   @GraphQLField

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLIdentifier.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLIdentifier.scala
@@ -46,8 +46,8 @@ class GraphQLIdentifier(identifier: Identifier) extends Node {
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular identifier.")
-  def deposit(implicit ctx: Context[DataContext, GraphQLIdentifier]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLIdentifier]): DeferredValue[DataContext, GraphQLDeposit] = {
     IdentifierResolver.depositByIdentifierId(ctx.value.id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLIngestStep.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLIngestStep.scala
@@ -45,9 +45,9 @@ class GraphQLIngestStep(ingestStep: IngestStep) extends Node {
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular ingest step.")
-  def deposit(implicit ctx: Context[DataContext, GraphQLIngestStep]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLIngestStep]): DeferredValue[DataContext, GraphQLDeposit] = {
     IngestStepResolver.depositByIngestStepId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 
   @GraphQLField

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLIsNewVersion.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLIsNewVersion.scala
@@ -44,9 +44,9 @@ class GraphQLIsNewVersion(isNewVersion: IsNewVersion) extends Node {
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular IsNewVersionEvent")
-  def deposit(implicit ctx: Context[DataContext, GraphQLIsNewVersion]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLIsNewVersion]): DeferredValue[DataContext, GraphQLDeposit] = {
     IsNewVersionResolver.depositByIsNewVersionId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 
   @GraphQLField

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLSpringfield.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLSpringfield.scala
@@ -52,8 +52,8 @@ class GraphQLSpringfield(springfield: Springfield) extends Node {
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular springfield configuration.")
-  def deposit(implicit ctx: Context[DataContext, GraphQLSpringfield]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLSpringfield]): DeferredValue[DataContext, GraphQLDeposit] = {
     SpringfieldResolver.depositBySpringfieldId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLState.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/GraphQLState.scala
@@ -49,9 +49,9 @@ class GraphQLState(state: State) extends Node {
 
   @GraphQLField
   @GraphQLDescription("Returns the deposit that is associated with this particular state")
-  def deposit(implicit ctx: Context[DataContext, GraphQLState]): DeferredValue[DataContext, Option[GraphQLDeposit]] = {
+  def deposit(implicit ctx: Context[DataContext, GraphQLState]): DeferredValue[DataContext, GraphQLDeposit] = {
     StateResolver.depositByStateId(id)
-      .map(_.map(new GraphQLDeposit(_)))
+      .map(new GraphQLDeposit(_))
   }
 
   @GraphQLField

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/Query.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/model/Query.scala
@@ -135,8 +135,8 @@ class Query {
   @GraphQLDescription("Find an identifier with the given type and value.")
   def identifier(@GraphQLName("type") @GraphQLDescription("The type of identifier to be found.") idType: IdentifierType.Value,
                  @GraphQLName("value") @GraphQLDescription("The value of the identifier to be found.") idValue: String,
-                )(implicit ctx: Context[DataContext, Unit]): DeferredValue[DataContext, Option[GraphQLIdentifier]] = {
+                )(implicit ctx: Context[DataContext, Unit]): DeferredValue[DataContext, GraphQLIdentifier] = {
     IdentifierResolver.identifierByTypeAndValue(idType, idValue)
-      .map(_.map(new GraphQLIdentifier(_)))
+      .map(new GraphQLIdentifier(_))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/ContentTypeResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/ContentTypeResolver.scala
@@ -41,8 +41,8 @@ object ContentTypeResolver {
       .map { case (_, contentTypes) => contentTypes }
   }
 
-  def depositByContentTypeId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByContentTypeIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByContentTypeId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByContentTypeIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/CuratorResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/CuratorResolver.scala
@@ -41,8 +41,8 @@ object CuratorResolver {
       .map { case (_, curators) => curators }
   }
 
-  def depositByCuratorId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByCuratorIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByCuratorId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByCuratorIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IdentifierResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IdentifierResolver.scala
@@ -42,9 +42,9 @@ object IdentifierResolver {
       .map(_.map { case (_, identifier) => identifier })
   }
   
-  def identifierByTypeAndValue(idType: IdentifierType, idValue: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Identifier]] = {
-    DeferredValue(identifierTypesAndValuesFetcher.deferOpt(idType -> idValue))
-      .map(_.map { case (_, identifier) => identifier })
+  def identifierByTypeAndValue(idType: IdentifierType, idValue: String)(implicit ctx: DataContext): DeferredValue[DataContext, Identifier] = {
+    DeferredValue(identifierTypesAndValuesFetcher.defer(idType -> idValue))
+      .map { case (_, identifier) => identifier }
   }
 
   def allById(depositId: DepositId)(implicit ctx: DataContext): DeferredValue[DataContext, Seq[Identifier]] = {
@@ -52,8 +52,8 @@ object IdentifierResolver {
       .map { case (_, identifiers) => identifiers }
   }
 
-  def depositByIdentifierId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByIdentifierIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByIdentifierId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByIdentifierIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IngestStepResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IngestStepResolver.scala
@@ -41,8 +41,8 @@ object IngestStepResolver {
       .map { case (_, ingestSteps) => ingestSteps }
   }
 
-  def depositByIngestStepId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByIngestStepIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByIngestStepId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByIngestStepIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IsCurationPerformedResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IsCurationPerformedResolver.scala
@@ -41,8 +41,8 @@ object IsCurationPerformedResolver {
       .map { case (_, isCurationPerformeds) => isCurationPerformeds }
   }
 
-  def depositByIsCurationPerformedId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByIsCurationPerformedIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByIsCurationPerformedId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByIsCurationPerformedIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IsCurationRequiredResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IsCurationRequiredResolver.scala
@@ -41,8 +41,8 @@ object IsCurationRequiredResolver {
       .map { case (_, isCurationRequireds) => isCurationRequireds }
   }
 
-  def depositByIsCurationRequiredId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByIsCurationRequiredIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByIsCurationRequiredId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByIsCurationRequiredIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IsNewVersionResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/IsNewVersionResolver.scala
@@ -41,8 +41,8 @@ object IsNewVersionResolver {
       .map { case (_, isNewVersions) => isNewVersions }
   }
 
-  def depositByIsNewVersionId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByIsNewVersionIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByIsNewVersionId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByIsNewVersionIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/SpringfieldResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/SpringfieldResolver.scala
@@ -41,8 +41,8 @@ object SpringfieldResolver {
       .map { case (_, springfields) => springfields }
   }
 
-  def depositBySpringfieldId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositBySpringfieldIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositBySpringfieldId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositBySpringfieldIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/StateResolver.scala
+++ b/src/main/scala/nl.knaw.dans.easy.properties/app/graphql/resolvers/StateResolver.scala
@@ -41,8 +41,8 @@ object StateResolver {
       .map { case (_, states) => states }
   }
 
-  def depositByStateId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Option[Deposit]] = {
-    DeferredValue(depositByStateIdFetcher.deferOpt(id))
-      .map(_.map { case (_, deposit) => deposit })
+  def depositByStateId(id: String)(implicit ctx: DataContext): DeferredValue[DataContext, Deposit] = {
+    DeferredValue(depositByStateIdFetcher.defer(id))
+      .map { case (_, deposit) => deposit }
   }
 }


### PR DESCRIPTION
Fixes EASY-

#### When applied it will
* remove unnecessary `Option` parameters from GraphQL interface

#### By submitting this pull request I confirm that
* [x] the changes have been tested on `deasy`

@DANS-KNAW/easy for review